### PR TITLE
Added modifyEnv option allowing easy environment modification

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,6 +132,21 @@ module.exports = function(grunt) {
                     data:       [ 'test/fixtures/test-data.json', 'test/fixtures/test-data.yml' ],
                     dest:       'tmp/template-string_file_content_append.html'
                 }]
+            },
+            modify_env: {
+                options: {
+                    modifyEnv: function (env) {
+                        env.addFilter('testModifyEnv', function (string) {
+                            // Whatever the string is we simply return sausages
+                            return "Sausages";
+                        });
+                        return env;
+                    }
+                },
+                files : [{
+                    str:        [ '{{ "Beans" | testModifyEnv }}' ],
+                    dest:       'tmp/template-modify_env.html'
+                }]
             }
         },
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ A "*template*" here is a raw template, defined as the `src` item of a target fil
     -   Default value: `"\n"`
     -   A string used to separate parsed strings between them and from templates contents.
 
+-   **modifyEnv**
+    -   Type: `Function`
+    -   Default value: `null`
+    -   A function that takes a Nunjucks Environment as the first argument and returns it with modifications, such as the addition of custom filters.
+
 #### Examples
 
 You can have a look at the `Gruntfile.js` of the plugin for various usage examples.
@@ -219,6 +224,25 @@ options: {
 my_target: {
     files: {
         data:   { desc: "my desc which will over-write global one" },
+        src:    'template/to/read.j2',
+        dest:   'file/to/output.html'
+    }
+}
+```
+
+Add a custom filter to the Nunjucks Environment:
+
+```js
+options: {
+    modifyEnv: function (env) {
+        env.addFilter('uppercase', function (str) {
+            return str.toUpperCase();
+        });
+        return env;
+    }
+},
+my_target: {
+    files: {
         src:    'template/to/read.j2',
         dest:   'file/to/output.html'
     }

--- a/tasks/nunjucks_render.js
+++ b/tasks/nunjucks_render.js
@@ -40,7 +40,8 @@ module.exports = function gruntTask(grunt) {
             processData:    function(data){ return data; },
             env:            null,
             strAdd:         'prepend',
-            strSeparator:   "\n"
+            strSeparator:   "\n",
+            modifyEnv:      null
         });
         
         // be sure to have extensions as an array with leading dot
@@ -69,8 +70,13 @@ module.exports = function gruntTask(grunt) {
         var env_opts = opts.env ? [opts.env, fileLoader] : [fileLoader];
         opts.env = new nunjucks.Environment(env_opts);
         
-        // add the date fileter to nunjucks env
+        // add the date filter to nunjucks env
         opts.env.addFilter('date', dateFilter);
+
+        // if the user has provided a function to modify the nunjucks environment, we apply it here
+        if (opts.modifyEnv !== null) {
+            opts.env = opts.modifyEnv(opts.env);
+        }
 
         // iterate over all specified file groups
         this.files.forEach(function(file)

--- a/test/expected/template-modify_env.html
+++ b/test/expected/template-modify_env.html
@@ -1,0 +1,1 @@
+Sausages

--- a/test/nunjucks_render_test.js
+++ b/test/nunjucks_render_test.js
@@ -127,6 +127,14 @@ exports.nunjucks_render = {
     var expected    = grunt.file.read('test/expected/template-string_file_content_append.html');
     test.equal(cleanUpDate(actual), cleanUpDate(expected), 'Test of string content with file parsing, strings appended.');
     test.done();
+  },
+
+  modify_env: function(test) {
+    test.expect(1);
+    var actual      = grunt.file.read('tmp/template-modify_env.html');
+    var expected    = grunt.file.read('test/expected/template-modify_env.html');
+    test.equal(cleanUpDate(actual), cleanUpDate(expected), 'Test of environment modifications via the modify_env option.');
+    test.done();
   }
 
 };


### PR DESCRIPTION
Improving on the existing env option by adding a new modifyEnv option. The option takes a function of the following form:

```
function (env) {
    ...
    return env;
}
```

This allows custom environments to be created much more easily than when using the env option, as well as allowing the custom environment to benefit from the extra template_date and template_path variables.
