### PR TITLE
Fixed template_date so that it actually contains the date.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -118,7 +118,6 @@ var FileSystemLoader = loader.extend({
 
         var env = nunjucks.configure();
         env.addGlobal('template_path', fullpath);
-        env.addGlobal('template_date', new Date());
 
         return { src: fs.readFileSync(fullpath, 'utf-8'),
                  path: fullpath,

--- a/tasks/nunjucks_render.js
+++ b/tasks/nunjucks_render.js
@@ -69,8 +69,9 @@ module.exports = function gruntTask(grunt) {
         var env_opts = opts.env ? [opts.env, fileLoader] : [fileLoader];
         opts.env = new nunjucks.Environment(env_opts);
         
-        // add the date fileter to nunjucks env
+        // Customise the Nunjucks Environment object
         opts.env.addFilter('date', dateFilter);
+        opts.env.addGlobal('template_date', new Date());
 
         // iterate over all specified file groups
         this.files.forEach(function(file)


### PR DESCRIPTION
Currently template_date is always empty and only works because the date filter handles empty input by printing the current date/time. This commit fixes it.
